### PR TITLE
dynamically generate tree populate metadata fields

### DIFF
--- a/js/tree.js
+++ b/js/tree.js
@@ -200,23 +200,17 @@ function updateTree(drawNodes = false) {
                       if (d.isTip) {
                           coords = d3.pointer(e);
                           let pos = d3.select(this).node().getBoundingClientRect();
-                          tooltip.html(
-                              "<p>" + 
-                              `<b>Province: </b>${d["province"]}<br/>` + 
-                              `<b>Sample date: </b>${d["sample.collection.date"]}<br/>` + 
-                              `<b>Host gender: </b>${d["host.gender"]}<br/>` + 
-                              `<b>Host age bin: </b>${d["host.age.bin"]}<br/>` + 
-                              `<b>Purpose of sampling: </b>${d["purpose.of.sampling"]}<br/>` + 
-                              `<b>Purpose of sequencing: </b>${d["purpose.of.sequencing"]}<br/>` + 
-                              `<b>Sample Source: </b>${d["sample.collected.by"]}<br/>` + 
-                              `<b>Lineage: </b>${d["lineage"]}<br/>` + 
-                              `<b>Pango Group: </b>${d["pango.group"]}<br/>` +             
-                              `<b>Sample Name: </b>${d["fasta.header.name"]}<br/>` +                                   
-                              "</p>" 
-                              ).style("visibility", "visible")
-                               .style("left", (coords[0] ) + "px")
-                               //.style("top", (coords[1] + yoffset - rdiv.scrollTop - 500) + "px");    
-                              //.style('left', `${pos['x']}px`)
+                          //populate the popout box text with ALL metadata columns
+                          var toolTipText = "<p>"  
+                          for(var i = 0; i < metadataFields.length; i++){
+                            cleanName = metadataFields[i].charAt(0).toUpperCase() + metadataFields[i].slice(1);
+                            cleanName = cleanName.split('.').join(' ');
+                            toolTipText = toolTipText + "<b>" + cleanName + `: </b>${d[metadataFields[i]]}<br/>` 
+                          }
+                          toolTipText = toolTipText + "</p>";
+                          tooltip.html(toolTipText)
+                              .style("visibility", "visible")
+                              .style("left", (coords[0] ) + "px")
                               .style('top', `${(window.pageYOffset  + pos['y'] +15)}px`);
                       }
                   })
@@ -237,24 +231,18 @@ function updateTree(drawNodes = false) {
         if (d.isTip) {
             coords = d3.pointer(e);
             let pos = d3.select(this).node().getBoundingClientRect();
-            tooltip.html(
-                "<p>" + 
-                `<b>Province: </b>${d["province"]}<br/>` + 
-                `<b>Sample date: </b>${d["sample.collection.date"]}<br/>` + 
-                `<b>Host gender: </b>${d["host.gender"]}<br/>` + 
-                `<b>Host age bin: </b>${d["host.age.bin"]}<br/>` + 
-                `<b>Purpose of sampling: </b>${d["purpose.of.sampling"]}<br/>` + 
-                `<b>Purpose of sequencing: </b>${d["purpose.of.sequencing"]}<br/>` + 
-                `<b>Sample Source: </b>${d["sample.collected.by"]}<br/>` + 
-                `<b>Lineage: </b>${d["lineage"]}<br/>` + 
-                `<b>Pango Group: </b>${d["pango.group"]}<br/>` +        
-                `<b>Sample Name: </b>${d["fasta.header.name"]}<br/>` +                                                        
-                "</p>" 
-                ).style("visibility", "visible")
-                 .style("left", (coords[0] ) + "px")
-                 //.style("top", (coords[1] + yoffset - rdiv.scrollTop - 500) + "px");    
-                //.style('left', `${pos['x']}px`)
-                .style('top', `${(window.pageYOffset  + pos['y'] +15)}px`);
+            //populate the popout box text with ALL metadata columns
+            var toolTipText = "<p>"  
+            for(var i = 0; i < metadataFields.length; i++){
+              cleanName = metadataFields[i].charAt(0).toUpperCase() + metadataFields[i].slice(1);
+              cleanName = cleanName.split('.').join(' ');
+              toolTipText = toolTipText + "<b>" + cleanName + `: </b>${d[metadataFields[i]]}<br/>` 
+            }
+            toolTipText = toolTipText + "</p>";
+            tooltip.html(toolTipText)
+              .style("visibility", "visible")
+              .style("left", (coords[0] ) + "px")
+              .style('top', `${(window.pageYOffset  + pos['y'] +15)}px`);
         }
     })
     .on("mouseout", function(e, d) {
@@ -415,6 +403,7 @@ function populateMetadataOptions(field){
 //function for populating the checkboxes for colorgroups
 //`d` is the dropdown object passed in as "this" with the onchange() function.
 //`value` is the workaround for default color scheme on page load.
+var metadataOptions = []
 function displayOptions(d, value = ""){
   var target;
   if (value != "") { //default view on page load
@@ -428,7 +417,7 @@ function displayOptions(d, value = ""){
 	optionDiv.selectAll("*").remove()
 	colorByDiv.selectAll("label").remove()
 
-  	var metadataOptions = populateMetadataOptions(target) //get all the unique values within a metadata column
+  	metadataOptions = populateMetadataOptions(target) //get all the unique values within a metadata column
   	var selectAllBox = colorByDiv //insert a select all checkbox
   	          .append("label")
               .html(function(d) {

--- a/js/tree.js
+++ b/js/tree.js
@@ -403,7 +403,6 @@ function populateMetadataOptions(field){
 //function for populating the checkboxes for colorgroups
 //`d` is the dropdown object passed in as "this" with the onchange() function.
 //`value` is the workaround for default color scheme on page load.
-var metadataOptions = []
 function displayOptions(d, value = ""){
   var target;
   if (value != "") { //default view on page load
@@ -417,7 +416,7 @@ function displayOptions(d, value = ""){
 	optionDiv.selectAll("*").remove()
 	colorByDiv.selectAll("label").remove()
 
-  	metadataOptions = populateMetadataOptions(target) //get all the unique values within a metadata column
+  	var metadataOptions = populateMetadataOptions(target) //get all the unique values within a metadata column
   	var selectAllBox = colorByDiv //insert a select all checkbox
   	          .append("label")
               .html(function(d) {

--- a/scripts/tree.r
+++ b/scripts/tree.r
@@ -3,6 +3,7 @@
 DrawTree <- function(tree, metadata, treeType, fieldnames = c("fasta.header.name", "province", "host.gender", "host.age.bin", "sample.collection.date", 
                                                     "sample.collected.by", "purpose.of.sampling", "purpose.of.sequencing",
                                                     "lineage", "pango.group")){
+  printest("test1")
   suppressWarnings(tt.layout <- tree.layout(tree, type='r'))
   #assign default colour to init color variable in json
   
@@ -14,17 +15,17 @@ DrawTree <- function(tree, metadata, treeType, fieldnames = c("fasta.header.name
     temp[tt.layout$edges$isTip] <- as.character(metadata[[field]])
     tt.layout$edges[[field]] <- temp
   }
+  view(tt.layout$edges)
   
   # append vertical edges
   v.edges <- t(sapply(split(tt.layout$edges, tt.layout$edges$parent), function(e) {
     x <- e[1,]$x0
     c(parent=NA, child=NA, length=NA, isTip=NA, 
       x0=x, x1=x, y0=min(e$y0), y1=max(e$y0),
-      colour=e[1,]$colour, fasta.header.name=NA, sample.collected.by=NA, sample.collection.date=NA,
-      province=NA, host.gender=NA, host.age.bin=NA, purpose.of.sampling=NA,
-      purpose.of.sequencing=NA, lineage=NA, pango.group=NA)
+      colour=e[1,]$colour)
   }))
-  edges <- rbind(tt.layout$edges, v.edges)  # tips, internals
+  view(v.edges)
+  edges <- merge(tt.layout$edges, v.edges, all=TRUE)  # tips, internals
   #view(max(edges$x1))
   jsonObj <- toJSON(list(nodes=tt.layout$nodes, edges=edges, treetype=treeType))
   

--- a/scripts/tree.r
+++ b/scripts/tree.r
@@ -3,7 +3,6 @@
 DrawTree <- function(tree, metadata, treeType, fieldnames = c("fasta.header.name", "province", "host.gender", "host.age.bin", "sample.collection.date", 
                                                     "sample.collected.by", "purpose.of.sampling", "purpose.of.sequencing",
                                                     "lineage", "pango.group")){
-  printest("test1")
   suppressWarnings(tt.layout <- tree.layout(tree, type='r'))
   #assign default colour to init color variable in json
   
@@ -15,7 +14,6 @@ DrawTree <- function(tree, metadata, treeType, fieldnames = c("fasta.header.name
     temp[tt.layout$edges$isTip] <- as.character(metadata[[field]])
     tt.layout$edges[[field]] <- temp
   }
-  view(tt.layout$edges)
   
   # append vertical edges
   v.edges <- t(sapply(split(tt.layout$edges, tt.layout$edges$parent), function(e) {
@@ -24,9 +22,7 @@ DrawTree <- function(tree, metadata, treeType, fieldnames = c("fasta.header.name
       x0=x, x1=x, y0=min(e$y0), y1=max(e$y0),
       colour=e[1,]$colour)
   }))
-  view(v.edges)
   edges <- merge(tt.layout$edges, v.edges, all=TRUE)  # tips, internals
-  #view(max(edges$x1))
   jsonObj <- toJSON(list(nodes=tt.layout$nodes, edges=edges, treetype=treeType))
   
   return(jsonObj)


### PR DESCRIPTION
dynamically generate the metadata fields for the pop out boxes on the tree so that whatever is specified in the `fieldname` variable is carried over everywhere.