### PR TITLE
Updated download script to add ViralAi as an alternative option for data

### DIFF
--- a/data_needed/download.sh
+++ b/data_needed/download.sh
@@ -5,46 +5,70 @@ tarcmd=$(case "$(uname -s)" in Darwin)  echo 'gtar';;  Linux) echo 'tar';; esac)
 datestamp=$(date --utc +%Y-%m-%dT%H_%M_%S)
 echo version will be stamped as : $datestamp
 
-(
-  # download tarball from VirusSeq
-  wget -O data_needed/virusseq.$datestamp.tar.gz https://singularity.virusseq-dataportal.ca/download/archive/all  > /dev/null 2>&1
-  # scan tarball for filenames
-  tar -ztf data_needed/virusseq.$datestamp.tar.gz > data_needed/.list_filenames$datestamp
-  # stream metadata into gz-compressed file
-  $tarcmd -axf data_needed/virusseq.$datestamp.tar.gz -O $(cat data_needed/.list_filenames$datestamp | grep tsv$) | gzip > data_needed/virusseq.$datestamp.metadata.tsv.gz
-  # stream FASTA data into xz-compressed file
-  $tarcmd -axf data_needed/virusseq.$datestamp.tar.gz -O $(cat data_needed/.list_filenames$datestamp | grep fasta$) | perl -p -e "s/\r//g" | xz > data_needed/virusseq.$datestamp.fasta.xz
-  # delete tarball
-  rm data_needed/virusseq.$datestamp.tar.gz data_needed/.list_filenames$datestamp
-)&
+data_dir=${PWD}/data_needed
+scripts_dir=${PWD}/scripts
+
+#get the json containing aliases
+wget -O ${data_dir}/alias_key.json https://raw.githubusercontent.com/cov-lineages/pango-designation/master/pango_designation/alias_key.json  > /dev/null 2>&1
+cat  ${data_dir}/alias_key.json | sed 's\[":,]\\g' | awk 'NF==2 && substr($1,1,1)!="X"{print "alias",$1,$2}' >  ${data_dir}/pango_designation_alias_key.json
 
 (
-  #get the json contain
-  wget -O data_needed/alias_key.json https://raw.githubusercontent.com/cov-lineages/pango-designation/master/pango_designation/alias_key.json  > /dev/null 2>&1
-  cat data_needed/alias_key.json | sed 's\[":,]\\g' | awk 'NF==2 && substr($1,1,1)!="X"{print "alias",$1,$2}' > data_needed/pango_designation_alias_key.json 
-  rm data_needed/alias_key.json
-  
-  #download pangolin calls from DNAstack and create a column with raw names (eg: BA.5 is B.1.1.529.5)
-  dnastack collections query virusseq "SELECT isolate, lineage, pangolin_version FROM collections.virusseq.public_samples" --format csv > data_needed/viralai.$datestamp.csv
-  ( cat data_needed/pango_designation_alias_key.json;cat data_needed/viralai.$datestamp.csv | tr ',' ' ')|
-    awk  '$1=="alias"{t[$2]=$3}$1!="alias"{rem=$2;split($2,p,".");if(p[1] in t){gsub(p[1]"." , t[p[1]]".", $2)}print $1,$2,rem,$3}' |
-    tr ' ' ',' | sed 's/lineage,lineage/rawlineage,lineage/g'> data_needed/viralai.$datestamp.withalias.csv
-  
-  
-  
-  #get the fasta from ncov
-  wget -O data_needed/ncov-open.$datestamp.fasta.xz https://data.nextstrain.org/files/ncov/open/sequences.fasta.xz  > /dev/null 2>&1
-  
+ #get the fasta from ncov
+  wget -O ${data_dir}/ncov-open.$datestamp.fasta.xz https://data.nextstrain.org/files/ncov/open/sequences.fasta.xz  > /dev/null 2>&1
+
   #get the metadata from ncov and add a column with raw names (eg: BA.5 is B.1.1.529.5)
-    wget -O data_needed/ncov-open.$datestamp.tsv.gz https://data.nextstrain.org/files/ncov/open/metadata.tsv.gz  > /dev/null 2>&1
+    wget -O ${data_dir}/ncov-open.$datestamp.tsv.gz https://data.nextstrain.org/files/ncov/open/metadata.tsv.gz  > /dev/null 2>&1
     (
-      cat data_needed/pango_designation_alias_key.json;
-      zcat data_needed/ncov-open.$datestamp.tsv.gz | tr ' ' '_' | sed 's/\t\t/\tNA\t/g' | sed 's/\t\t/\tNA\t/g'| sed 's/\t$/\tNA/g'
+      cat ${data_dir}/pango_designation_alias_key.json;
+      zcat ${data_dir}/ncov-open.$datestamp.tsv.gz | tr ' ' '_' | sed 's/\t\t/\tNA\t/g' | sed 's/\t\t/\tNA\t/g'| sed 's/\t$/\tNA/g'
       ) |
     awk  '$1=="alias"{t[$2]=$3;next;}$1=="strain"{for(i=1;i<=NF;i++){if($i=="pango_lineage"){col=i;print $0,"rawlineage";next;}}}{rem=$i;split($i,p,".");if(p[1] in t){gsub(p[1]"." , t[p[1]]".", $i)};raw=$i;$i=rem;print $0,raw}' |
-    tr ' ' '\t'  | gzip > data_needed/ncov-open.$datestamp.withalias.tsv.gz
+    tr ' ' '\t'  | gzip > ${data_dir}/ncov-open.$datestamp.withalias.tsv.gz
+)&
+
+
+(
+  if [[ $1 == "ViralAi" ]]
+  then
+
+          echo "Data source is ViralAi"
+          cat  ${data_dir}/alias_key.json | sed 's\[":,]\\g' | awk 'NF==2 && substr($1,1,1)!="X"{print $1,$2}' |  tr ' ' \\t  >  ${data_dir}/pango_designation_alias_key_viralai.tsv
+          sed -i '1i alias\tlineage'  ${data_dir}/pango_designation_alias_key_viralai.tsv
+          rm  ${data_dir}/alias_key.json
+          (
+            python  $scripts_dir}/viralai_fetch_metadata.py --alias 
+${data_dir}/pango_designation_alias_key_viralai.tsv --csv ${data_dir}/virusseq.$datestamp.metadata.tsv && gzip ${data_dir}/virusseq.$datestamp.metadata.tsv
+          )
+          (
+            mkdir -p  ${data_dir}/temp
+            python  ${scripts_dir}/viralai_fetch_fasta_url.py --seq  
+${data_dir}/temp/fasta_drl.$datestamp.txt
+            dnastack files download -i  ${data_dir}/temp/fasta_drl.$datestamp.txt -o ${data_dir}/temp
+            mv ${data_dir}/temp/*.fa ${data_dir}/virusseq.$datestamp.fasta && xz -T0 ${data_dir}/virusseq.$datestamp.fasta
+            rm -r  ${data_dir}/temp
+          )
+
+
+  else
+        (
+          echo "Data source is VirusSeq"
+          # download tarball from VirusSeq
+          wget -O ${data_dir}/virusseq.$datestamp.tar.gz https://singularity.virusseq-dataportal.ca/download/archive/all  > /dev/null 2>&1
+          # scan tarball for filenames
+          tar -ztf ${data_dir}/virusseq.$datestamp.tar.gz > ${data_dir}/.list_filenames$datestamp
+          # stream metadata into gz-compressed file
+          $tarcmd -axf ${data_dir}/virusseq.$datestamp.tar.gz -O $(cat data_needed/.list_filenames$datestamp | grep tsv$) | gzip > ${data_dir}/virusseq.$datestamp.metadata.tsv.gz
+          # stream FASTA data into xz-compressed file
+          $tarcmd -axf ${data_dir}/virusseq.$datestamp.tar.gz -O $(cat data_needed/.list_filenames$datestamp | grep fasta$) | perl -p -e "s/\r//g" | xz -T0 > ${data_dir}/virusseq.$datestamp.fasta.xz
+          # delete tarball
+          rm ${data_dir}/virusseq.$datestamp.tar.gz ${data_dir}/.list_filenames$datestamp
+
+          dnastack collections query virusseq "SELECT isolate, lineage, pangolin_version FROM collections.virusseq.public_samples" --format csv > ${data_dir}/viralai.$datestamp.csv
+          ( cat ${data_dir}/pango_designation_alias_key.json;cat data_needed/viralai.$datestamp.csv | tr ',' ' ') | awk  '$1=="alias"{t[$2]=$3}$1!="alias"{rem=$2;split($2,p,".");if(p[1] in t){gsub(p[1]"." , t[p[1]]".", $2)}print $1,$2,rem,$3}' |
+          tr ' ' ',' | sed 's/lineage,lineage/rawlineage,lineage/g'> ${data_dir}/viralai.$datestamp.withalias.csv
+        )
+  fi
+
 )&
 
 wait $(jobs -p | tr '\n' ' ')
-
-

--- a/data_needed/download.sh
+++ b/data_needed/download.sh
@@ -36,7 +36,7 @@ cat  ${data_dir}/alias_key.json | sed 's\[":,]\\g' | awk 'NF==2 && substr($1,1,1
           sed -i '1i alias\tlineage'  ${data_dir}/pango_designation_alias_key_viralai.tsv
           rm  ${data_dir}/alias_key.json
           (
-            python  ${scripts_dir}/viralai_fetch_metadata.py --alias ${data_dir}/pango_designation_alias_key_viralai.tsv --csv ${data_dir}/virusseq.$datestamp.metadata.tsv && gzip ${data_dir}/virusseq.$datestamp.metadata.tsv
+            python  ${scripts_dir}/viralai_fetch_metadata.py --alias ${data_dir}/pango_designation_alias_key_viralai.tsv --csv ${data_dir}/virusseq.metadata.csv.gz
           )
           (
             mkdir -p  ${data_dir}/temp

--- a/data_needed/download.sh
+++ b/data_needed/download.sh
@@ -36,13 +36,11 @@ cat  ${data_dir}/alias_key.json | sed 's\[":,]\\g' | awk 'NF==2 && substr($1,1,1
           sed -i '1i alias\tlineage'  ${data_dir}/pango_designation_alias_key_viralai.tsv
           rm  ${data_dir}/alias_key.json
           (
-            python  $scripts_dir}/viralai_fetch_metadata.py --alias 
-${data_dir}/pango_designation_alias_key_viralai.tsv --csv ${data_dir}/virusseq.$datestamp.metadata.tsv && gzip ${data_dir}/virusseq.$datestamp.metadata.tsv
+            python  ${scripts_dir}/viralai_fetch_metadata.py --alias ${data_dir}/pango_designation_alias_key_viralai.tsv --csv ${data_dir}/virusseq.$datestamp.metadata.tsv && gzip ${data_dir}/virusseq.$datestamp.metadata.tsv
           )
           (
             mkdir -p  ${data_dir}/temp
-            python  ${scripts_dir}/viralai_fetch_fasta_url.py --seq  
-${data_dir}/temp/fasta_drl.$datestamp.txt
+            python  ${scripts_dir}/viralai_fetch_fasta_url.py --seq ${data_dir}/temp/fasta_drl.$datestamp.txt
             dnastack files download -i  ${data_dir}/temp/fasta_drl.$datestamp.txt -o ${data_dir}/temp
             mv ${data_dir}/temp/*.fa ${data_dir}/virusseq.$datestamp.fasta && xz -T0 ${data_dir}/virusseq.$datestamp.fasta
             rm -r  ${data_dir}/temp

--- a/scripts/viralai_fetch_fasta_url.py
+++ b/scripts/viralai_fetch_fasta_url.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import argparse
+# Import the dnastack-client-library library
+from dnastack import CollectionServiceClient
+from dnastack.configuration import ServiceEndpoint
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Downlaod info for multifasta file hosted at ViralAi')
+    parser.add_argument('--seq', type=str, default=None,
+                        help='seq file')
+
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    # Create the client
+    api_url = 'https://viral.ai/api/'
+    client = CollectionServiceClient.make(ServiceEndpoint(adapter_type="collections", url=api_url))
+
+    # Get the Data Connect client for a specific collection
+    collection_name = 'virusseq'
+    data_connect_client = client.get_data_connect_client(collection_name)
+
+    # Dowload fasta files information
+    query = "SELECT * FROM viralai.virusseq.files WHERE NAME LIKE '%multifasta%'"
+    seq_df = pd.DataFrame(data_connect_client.query(query))
+    seq_df = seq_df.sort_values(by='created_time', ascending=False)
+    seq_df.head(1).to_csv(args.seq, encoding='utf-8', index=False, sep='\t', header=False, columns=["drs_url"])

--- a/scripts/viralai_fetch_metadata.py
+++ b/scripts/viralai_fetch_metadata.py
@@ -35,22 +35,6 @@ if __name__ == '__main__':
     query = """SELECT * FROM collections.virusseq.public_samples"""
     df = pd.DataFrame(data_connect_client.query(query))
 
-    if not df['gisaid_accession'].is_unique():
-        df.to_csv(args.csv.replace("metadata.tsv",
-                                   "gisaid_duplicates.tsv"),
-                  encoding='utf-8',
-                  index=False,
-                  sep='\t',
-                  columns=df['gisaid_accession'])
-
-    if not df['isolate'].is_unique():
-        df.to_csv(args.csv.replace("metadata.tsv",
-                                   "virusseq_duplicates.tsv"),
-                  encoding='utf-8',
-                  index=False,
-                  sep='\t',
-                  columns=df['isolate'])
-
     df['rawlineage'] = df['lineage']
     alias_df = pd.read_csv(args.alias, sep='\t', header=0)
     alias_dic = pd.Series(alias_df.lineage.values,
@@ -60,3 +44,16 @@ if __name__ == '__main__':
 
     # Sort by sample_collection_date and write it to csv
     df.to_csv(args.csv, encoding='utf-8', index=False, sep='\t', compressio='gzip')
+
+    if not df['gisaid_accession'].dropna().is_unique:
+        df[df['gisaid_accession'].duplicated(keep=False)].to_csv(
+            args.csv.replace("metadata.csv.gz",
+                             "gisaid_duplicate_ids.txt"),
+            encoding='utf-8', index=False, sep='\t',  columns=[
+                'gisaid_accession'])
+
+    if not df['isolate'].is_unique:
+        df[df['isolate'].duplicated(keep=False)].to_csv(
+            args.csv.replace("metadata.csv.gz", "duplicate_ids.txt"),
+            encoding='utf-8', index=False, sep='\t', columns=[
+                'isolate'])

--- a/scripts/viralai_fetch_metadata.py
+++ b/scripts/viralai_fetch_metadata.py
@@ -43,7 +43,8 @@ if __name__ == '__main__':
                                                             .map(alias_dic) + "." + df['rawlineage'].str.split(".",1).str[1]).fillna(df['rawlineage'])
 
     # Sort by sample_collection_date and write it to csv
-    df.to_csv(args.csv, encoding='utf-8', index=False, sep='\t', compressio='gzip')
+    df.to_csv(args.csv, encoding='utf-8', index=False, sep='\t',
+              compression='gzip')
 
     if not df['gisaid_accession'].dropna().is_unique:
         df[df['gisaid_accession'].duplicated(keep=False)].to_csv(

--- a/scripts/viralai_fetch_metadata.py
+++ b/scripts/viralai_fetch_metadata.py
@@ -1,0 +1,62 @@
+import pandas as pd
+import argparse
+from datetime import datetime
+
+# Import the dnastack-client-library library
+from dnastack import CollectionServiceClient
+from dnastack.configuration import ServiceEndpoint
+import re
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Download metadata from ViralAi')
+    parser.add_argument('--alias', type=str, default=None,
+                        help='.tsv file')
+    parser.add_argument('--csv', type=str, default=None,
+                        help='.csv file')
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    # Create the client
+    api_url = 'https://viral.ai/api/'
+    client = CollectionServiceClient.make(ServiceEndpoint(
+        adapter_type="collections", url=api_url))
+
+    # Get the Data Connect client for a specific collection
+    collection_name = 'virusseq'
+    data_connect_client = client.get_data_connect_client(
+        collection_name)
+
+    query = """SELECT * FROM collections.virusseq.public_samples"""
+    df = pd.DataFrame(data_connect_client.query(query))
+
+    if not df['gisaid_accession'].is_unique():
+        df.to_csv(args.csv.replace("metadata.tsv",
+                                   "gisaid_duplicates.tsv"),
+                  encoding='utf-8',
+                  index=False,
+                  sep='\t',
+                  columns=df['gisaid_accession'])
+
+    if not df['isolate'].is_unique():
+        df.to_csv(args.csv.replace("metadata.tsv",
+                                   "virusseq_duplicates.tsv"),
+                  encoding='utf-8',
+                  index=False,
+                  sep='\t',
+                  columns=df['isolate'])
+
+    df['rawlineage'] = df['lineage']
+    alias_df = pd.read_csv(args.alias, sep='\t', header=0)
+    alias_dic = pd.Series(alias_df.lineage.values,
+                          index=alias_df.alias).to_dict()
+    df['rawlineage']=(df['rawlineage'].str.extract(r"([A-Z]+)",expand=False)
+                                                            .map(alias_dic) + "." + df['rawlineage'].str.split(".",1).str[1]).fillna(df['rawlineage'])
+
+    # Sort by sample_collection_date and write it to csv
+    df.to_csv(args.csv, encoding='utf-8', index=False, sep='\t')

--- a/scripts/viralai_fetch_metadata.py
+++ b/scripts/viralai_fetch_metadata.py
@@ -35,12 +35,13 @@ if __name__ == '__main__':
     query = """SELECT * FROM collections.virusseq.public_samples"""
     df = pd.DataFrame(data_connect_client.query(query))
 
-    df['rawlineage'] = df['lineage']
+    df['raw_lineage'] = df['lineage']
     alias_df = pd.read_csv(args.alias, sep='\t', header=0)
     alias_dic = pd.Series(alias_df.lineage.values,
                           index=alias_df.alias).to_dict()
-    df['rawlineage']=(df['rawlineage'].str.extract(r"([A-Z]+)",expand=False)
-                                                            .map(alias_dic) + "." + df['rawlineage'].str.split(".",1).str[1]).fillna(df['rawlineage'])
+    df['raw_lineage']=(df['raw_lineage'].str.extract(r"([A-Z]+)",
+                                                    expand=False)
+                                                            .map(alias_dic) + "." + df['raw_lineage'].str.split(".",1).str[1]).fillna(df['raw_lineage'])
 
     # Sort by sample_collection_date and write it to csv
     df.to_csv(args.csv, encoding='utf-8', index=False, sep='\t',

--- a/scripts/viralai_fetch_metadata.py
+++ b/scripts/viralai_fetch_metadata.py
@@ -59,4 +59,4 @@ if __name__ == '__main__':
                                                             .map(alias_dic) + "." + df['rawlineage'].str.split(".",1).str[1]).fillna(df['rawlineage'])
 
     # Sort by sample_collection_date and write it to csv
-    df.to_csv(args.csv, encoding='utf-8', index=False, sep='\t')
+    df.to_csv(args.csv, encoding='utf-8', index=False, sep='\t', compressio='gzip')


### PR DESCRIPTION
`download.sh` now can take an argument `ViralAi` to allow data download from ViralAi instead of VirusSeq Data portal. This is significantly faster. 
It also maps aliases to lineages and removes the step of fetching lineages from ViralAi. 
The updated `download.sh` script uses 2 separate scripts to fetch metadata and fasta URL. This process can be even faster with more memory at hand.