### PR TITLE
Bugfix for individual checkbox selection in interactive tre

### DIFF
--- a/duotang.Rmd
+++ b/duotang.Rmd
@@ -135,7 +135,7 @@ meta$week <- cut(meta$sample_collection_date, 'week')
 source("scripts/scanlineages.R")
 meta$pango_group <- create.pango.group(VOCVOI, meta)
 meta$pango_group <- as.factor(meta$pango_group)
-
+meta[meta == ""] <- "Unknown"
 ## 2. LOAD epidemiological data (PHAC)
 
 
@@ -818,7 +818,6 @@ metasub1 <- meta[meta$fasta_header_name%in% ttree$tip.label, fieldnames]
 # sort rows to match tip labels in tree
 metasub1 <- metasub1[match(ttree$tip.label, metasub1$fasta_header_name), ]
 metasub_omi <- metasub1[grepl("Omicron",metasub1$pango_group ), ]
-
 #scale to number of mutations
 mltree$edge.length <- mltree$edge.length*29903
 

--- a/js/tree.js
+++ b/js/tree.js
@@ -201,11 +201,11 @@ function updateTree(drawNodes = false) {
                           let pos = d3.select(this).node().getBoundingClientRect();
                           //populate the popout box text with ALL metadata columns
                           var toolTipText = "<p>"  
-                          for(var i = 0; i < metadataFields.length; i++){
-                            cleanName = metadataFields[i].charAt(0).toUpperCase() + metadataFields[i].slice(1);
-                            cleanName = cleanName.split('.').join(' ');
-                            toolTipText = toolTipText + "<b>" + cleanName + `: </b>${d[metadataFields[i]]}<br/>` 
-                          }
+							for(var i = 0; i < metadataFields.length; i++){
+							  cleanName = metadataFields[i].charAt(0).toUpperCase() + metadataFields[i].slice(1);
+							  cleanName = cleanName.split('_').join(' ');
+							  toolTipText = toolTipText + "<b>" + cleanName + `: </b>${d[metadataFields[i]]}<br/>` 
+							}
                           toolTipText = toolTipText + "</p>";
                           tooltip.html(toolTipText)
                               .style("visibility", "visible")
@@ -234,7 +234,7 @@ function updateTree(drawNodes = false) {
             var toolTipText = "<p>"  
             for(var i = 0; i < metadataFields.length; i++){
               cleanName = metadataFields[i].charAt(0).toUpperCase() + metadataFields[i].slice(1);
-              cleanName = cleanName.split('.').join(' ');
+              cleanName = cleanName.split('_').join(' ');
               toolTipText = toolTipText + "<b>" + cleanName + `: </b>${d[metadataFields[i]]}<br/>` 
             }
             toolTipText = toolTipText + "</p>";

--- a/js/tree.js
+++ b/js/tree.js
@@ -301,8 +301,12 @@ var coloredGroups = {}
 //`chkbox` is the HTML checkbox object passed in as "this" from the onchange() function.
 function changeSingleOptionColor(chkbox){
   const target = chkbox.control.id.split("_");
-  var colorBy = target[0];
-  var idToColor = target[1];
+  console.log(target)
+  var idToColor = target.pop();
+  var colorBy = target.join("_");
+  console.log(idToColor)
+  console.log(colorBy)
+
   var n = 0 //counter for number of edges with color X
   if (chkbox.children[0].checked == true){ //set a color because box checked
     //if more than 12 colors, just give up being qualitative and use a random color
@@ -456,7 +460,7 @@ for(var i = 0; i < data.edges.length; i++){
     }
   }
 }
-var fieldsToRemove = ["parent", "child","colour", "length", "isTip","x0", "x1","y0","y1", "fasta.header.name"] //list of keys that are not metadata
+var fieldsToRemove = ["parent", "child","colour", "length", "isTip","x0", "x1","y0","y1", "fasta_header_name"] //list of keys that are not metadata
 //remove the non-metadata keys.
 metadataFields = metadataFields.filter( function( el ) {
   return !fieldsToRemove.includes( el );

--- a/js/tree.js
+++ b/js/tree.js
@@ -175,7 +175,6 @@ var xmax = d3.max(data.edges, e => e.x1),
     ylScale = d3.scaleLinear().domain([0, ntips]).range([lgheight, 0]),
     yoffset = absolutePosition(svg.node());
   
-  console.log(xmax)
 /* #endregion */
 //function called when the div needs to be re-rendered due to an update
 //`drawNodes` is a flag for drawing circles at the tip of the branches. Defaults to false.
@@ -301,12 +300,9 @@ var coloredGroups = {}
 //`chkbox` is the HTML checkbox object passed in as "this" from the onchange() function.
 function changeSingleOptionColor(chkbox){
   const target = chkbox.control.id.split("_");
-  console.log(target)
   var idToColor = target.pop();
   var colorBy = target.join("_");
-  console.log(idToColor)
-  console.log(colorBy)
-
+  
   var n = 0 //counter for number of edges with color X
   if (chkbox.children[0].checked == true){ //set a color because box checked
     //if more than 12 colors, just give up being qualitative and use a random color


### PR DESCRIPTION
bugfix for current tree with broken individual selection checkboxes. This is caused by "\_" being used in the metadata column as well as "\_" being used as ID for checkbox div elements, which breaks the string match javascript code. 